### PR TITLE
Agregado de función para escribir y visualizar resultados en Gmsh

### DIFF
--- a/funciones_algoritmo_vf.py
+++ b/funciones_algoritmo_vf.py
@@ -112,3 +112,30 @@ def cc_dirichlet(dict_fisico, dict_nodos, dict_condiciones, matriz):
     matriz[U_cond.nonzero(),:] = I[U_cond.nonzero()]
     fuente = U_cond
     return matriz, fuente
+#%
+def escribir_resultado(array_resultados, filename):
+    """Función que escribe al archivo .msh los resultados de la simulación.
+    Anexa al final del archivo el escalar temperatura. Se puede abrir
+    directamente con el programa 'Gmsh'. El formato de .msh es 4.1.
+    Información sobre el formato para escribir en
+    https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format
+
+    La cantidad de nodos se obtiene del tamaño del array de resultados.
+    Debido a que la indexación de Gmsh comienza con '1', debe añadirse
+    la unidad a la numeración de numpy.
+    Los resultados de temperatura corresponde a los valores del array.
+    """
+
+    with open(filename+'.msh', 'a') as archivo:
+        archivo.write('$NodeData\n')
+        archivo.write('1\n')    # 1 string tag
+        archivo.write('"Temperatura"\n')  # the name of the view
+        archivo.write('1\n')    # 1 real tag
+        archivo.write('0.0\n')  # the time value
+        archivo.write('3\n')    # 3 integer tags:
+        archivo.write('0\n')    # the time step
+        archivo.write('1\n')    # 1-component (scalar) field
+        archivo.write(f"{array_resultados.size}\n") # N associated nodal values
+        for nodo, valor in np.ndenumerate(array_resultados):
+            archivo.write("{n} {v}\n".format(n=nodo[0]+1, v=valor))
+        archivo.write('$EndNodeData\n')

--- a/tp2_main.py
+++ b/tp2_main.py
@@ -52,7 +52,9 @@ M = csc_matrix(Matriz_Global)
 # Resolver el sistema lineal AX = B
 # Temperaturas = splinalg.spsolve(M, fuente)
 Temperaturas, istop, itn, normr = splinalg.lsqr(M, fuente)[:4]
-print("Temperaturas")
-show_matrix(Temperaturas)
+
+# Escritura al archivo .msh de los resultados, para visualizar con Gmsh
+print("Escritura a archivo .msh de las temperaturas")
+funcion.escribir_resultado(Temperaturas, filename)
 #-----------------------------------------------------------
 # %%


### PR DESCRIPTION
Chris, agregué la función 'escribir_resultado' en el archivo 'funciones_...'.

Lee directamente el array de resultados, y los escribo al final del archivo .msh

No uso la API de gmsh en python, escribo directamente los resultados.

Agregué las lineas en el archivo 'tp2_main...' para que se pueda ver.